### PR TITLE
Add Support to update Blog posts when they already exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Project Specifics
+.vscode

--- a/md2cf/__main__.py
+++ b/md2cf/__main__.py
@@ -83,7 +83,7 @@ def get_parser():
         "--title",
         help="a title for the page. Determined from the document if missing",
     )
-    
+
     page_group.add_argument(
         "-c",
         "--content-type",
@@ -243,6 +243,7 @@ def upsert_page(
     existing_page = confluence.get_page(
         title=page.title,
         space_key=page.space,
+        content_type=page.content_type,
         page_id=page.page_id,
         additional_expansions=["space", "history", "version", "metadata.labels"],
     )
@@ -314,6 +315,7 @@ def upsert_page(
                 page=existing_page,
                 body=page.body,
                 parent_id=page.parent_id,
+                content_type=page.content_type,
                 update_message=page_message,
                 labels=page.labels if replace_all_labels else None,
                 minor_edit=minor_edit,

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -28,7 +28,12 @@ class MinimalConfluence:
             )
 
     def get_page(
-        self, title=None, space_key=None, page_id=None, content_type="page", additional_expansions=None
+        self,
+        title=None,
+        space_key=None,
+        page_id=None,
+        content_type="page",
+        additional_expansions=None,
     ):
         """
         Create a new page in a space
@@ -68,7 +73,14 @@ class MinimalConfluence:
             raise ValueError("At least one of title or page_id must not be None")
 
     def create_page(
-        self, space, title, body, content_type="page", parent_id=None, update_message=None, labels=None
+        self,
+        space,
+        title,
+        body,
+        content_type="page",
+        parent_id=None,
+        update_message=None,
+        labels=None,
     ):
         """
         Create a new page in a space

--- a/md2cf/api.py
+++ b/md2cf/api.py
@@ -28,7 +28,7 @@ class MinimalConfluence:
             )
 
     def get_page(
-        self, title=None, space_key=None, page_id=None, additional_expansions=None
+        self, title=None, space_key=None, page_id=None, content_type="page", additional_expansions=None
     ):
         """
         Create a new page in a space
@@ -36,6 +36,7 @@ class MinimalConfluence:
         Args:
             title (str): the title for the page
             space_key (str): the Confluence space for the page
+            content_type (str): Content type. Default value: page. Valid values: page, blogpost.
             page_id (str or int): the ID of the page
             additional_expansions (list of str): Additional expansions that should be made when calling the api
 
@@ -50,7 +51,7 @@ class MinimalConfluence:
         if page_id is not None:
             return self.api.content.get(page_id, params=params)
         elif title is not None:
-            params = {"title": title}
+            params = {"title": title, "type": content_type}
             if space_key is not None:
                 params["spaceKey"] = space_key
             response = self.api.content.get(params=params)
@@ -112,6 +113,7 @@ class MinimalConfluence:
         page,
         body,
         parent_id=None,
+        content_type="page",
         update_message=None,
         labels=None,
         minor_edit=False,
@@ -122,7 +124,7 @@ class MinimalConfluence:
                 "minorEdit": minor_edit,
             },
             "title": page.title,
-            "type": "page",
+            "type": content_type,
             "body": {"storage": {"value": body, "representation": "storage"}},
         }
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -31,6 +31,7 @@ def test_upsert_page(mocker):
             mocker.call(
                 title=page.title,
                 space_key=page.space,
+                content_type=page.content_type,
                 page_id=None,
                 additional_expansions=[
                     "space",


### PR DESCRIPTION
I ran into a problem when trying to update a blog post, existing blog posts where not found when running the CLI, so there is a failure when it tries to create a new blog post.

Fixed the query to look for existing Blog Posts
Updated the test suite
All tests pass